### PR TITLE
Small mistakes spotted in the first code example

### DIFF
--- a/doc/manual-out.md
+++ b/doc/manual-out.md
@@ -200,10 +200,10 @@ spawn {
             }
         }
     }
-    println(:done)
+    println(":done")
 }
-broadcast :tick                         ;; <-- :tick-1, tick-2
-broadcast :tick                         ;; <-- :tick-1, tick-2
+broadcast :tick                         ;; <-- :tick-1, :tick-2
+broadcast :tick                         ;; <-- :tick-1, :tick-2
 broadcast :done                         ;; <-- :done
 println("the end")                      ;; <-- the end
 ```


### PR DESCRIPTION
":done" wasn't marked as a string, and the leading colon of :tick-2 was forgotten in the printed output